### PR TITLE
Fix python_version format

### DIFF
--- a/ciscotalosintelligence.json
+++ b/ciscotalosintelligence.json
@@ -7,10 +7,7 @@
     "logo": "ciscotalosintelligence.svg",
     "logo_dark": "ciscotalosintelligence_dark.svg",
     "product_name": "Talos Intelligence",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "latest_tested_versions": [
         "Cloud, October 30, 2024"
     ],

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)